### PR TITLE
Use DisableIdleCamera native

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,12 +1,10 @@
-local idleCamDisabled = GetResourceKvpString("idleCam") ~= "on"
-
 RegisterCommand('idlecamoff', function() -- help2 31, 167, 9
   TriggerEvent('chat:addMessage', {
     color = {227,8,0},
     multiline = true,
     args = {'[COMMANDS]', 'Idle Cam Is Now Off'}
   })
-  idleCamDisabled = true
+  DisableIdleCam(true)
   SetResourceKvp("idleCam", "off")
 end)
 
@@ -16,20 +14,14 @@ RegisterCommand('idlecamon', function() -- help2 31, 167, 9
     multiline = true,
     args = {'[COMMANDS]', 'Idle Cam Is Now On'}
   })
-  idleCamDisabled = false
-    SetResourceKvp("idleCam", "on")
+  DisableIdleCam(false)
+  SetResourceKvp("idleCam", "on")
 end)
 
 Citizen.CreateThread(function()
   TriggerEvent("chat:addSuggestion", "/idlecamon", "Re-enables the idle cam")
   TriggerEvent("chat:addSuggestion", "/idlecamoff", "Disables the idle cam")
-  while true do
-    if idleCamDisabled then
-      InvalidateIdleCam()
-      InvalidateVehicleIdleCam()
-      Citizen.Wait(10000)
-    else
-      Citizen.Wait(3300)
-    end
-  end
+  
+  local idleCamDisabled = GetResourceKvpString("idleCam") ~= "on"
+  DisableIdleCam(idleCamDisabled)
 end)

--- a/client.lua
+++ b/client.lua
@@ -4,7 +4,7 @@ RegisterCommand('idlecamoff', function() -- help2 31, 167, 9
     multiline = true,
     args = {'[COMMANDS]', 'Idle Cam Is Now Off'}
   })
-  DisableIdleCam(true)
+  DisableIdleCamera(true)
   SetResourceKvp("idleCam", "off")
 end)
 
@@ -14,7 +14,7 @@ RegisterCommand('idlecamon', function() -- help2 31, 167, 9
     multiline = true,
     args = {'[COMMANDS]', 'Idle Cam Is Now On'}
   })
-  DisableIdleCam(false)
+  DisableIdleCamera(false)
   SetResourceKvp("idleCam", "on")
 end)
 
@@ -23,5 +23,5 @@ Citizen.CreateThread(function()
   TriggerEvent("chat:addSuggestion", "/idlecamoff", "Disables the idle cam")
   
   local idleCamDisabled = GetResourceKvpString("idleCam") ~= "on"
-  DisableIdleCam(idleCamDisabled)
+  DisableIdleCamera(idleCamDisabled)
 end)


### PR DESCRIPTION
Use the DisableIdleCamera native to enable/disable the idle cam permanently, rather than periodically invalidating the idle cam.